### PR TITLE
Fixes

### DIFF
--- a/git-id
+++ b/git-id
@@ -66,5 +66,5 @@ while choice is None:
 
 identity = identities[choice]
 
-subprocess.Popen(["git", "config", "user.email", identity["email"]])
-subprocess.Popen(["git", "config", "user.name", identity["name"]])
+subprocess.run(["git", "config", "user.email", identity["email"]])
+subprocess.run(["git", "config", "user.name", identity["name"]])

--- a/git-id
+++ b/git-id
@@ -54,7 +54,7 @@ while choice is None:
         choice = input()
     except KeyboardInterrupt:
         sys.exit(0)
-    if choice is "":
+    if choice == "":
         choice = cur_id
         break
     try:


### PR DESCRIPTION
- Fix the string comparison using the correct operator.
- Fix git locking error messages by using run() instead of Popen(). The former waits for completion of the subprocess. Thus, the processes may no longer run concurrently and locking each other.